### PR TITLE
DEV-14194 Enable cancel button in infinitely spinning comment when a document has a save error

### DIFF
--- a/src/ui/shared/AddOrEditFormFooter.tsx
+++ b/src/ui/shared/AddOrEditFormFooter.tsx
@@ -38,7 +38,7 @@ function AddOrEditFormFooter({
 
 			<Flex justifyContent="flex-end">
 				<Button
-					isDisabled={isDisabled}
+					isDisabled={isDisabled && !isLoading}
 					label={t('Cancel')}
 					onClick={onCancel}
 				/>


### PR DESCRIPTION
As a summary, I have fixed the problem by enabling the cancel button, when we do not indicate that it must be disabled and the review annotation is not loading (which happens when we are saving a comment, for example). 

Then, I have decided not to add tests because I haven't found any way to simulate that the server is disconnected in E2E tests. Unit tests were discarded as it is not possible to test a component rendering with them. However, if you know how I could test this, I would try to implement a test for this issue.