### PR TITLE
DEV-14072 Add reply input field on change proposals in Review route + DEV-14559 Add 'Reply' label to Reply button

### DIFF
--- a/src/ui/proposal/ProposalAddOrEditForm.tsx
+++ b/src/ui/proposal/ProposalAddOrEditForm.tsx
@@ -1,3 +1,5 @@
+import React, { useCallback, useEffect } from 'react';
+
 import {
 	Block,
 	Flex,
@@ -5,9 +7,7 @@ import {
 	Icon,
 	TextArea,
 	TextAreaWithDiff,
-} from 'fds/components';
-import React, { useCallback, useEffect } from 'react';
-
+} from 'fontoxml-design-system/src/components';
 import ReviewAnnotationForm from 'fontoxml-feedback/src/ReviewAnnotationForm';
 import { BusyState, RecoveryOption } from 'fontoxml-feedback/src/types';
 import t from 'fontoxml-localization/src/t';

--- a/src/ui/proposal/ProposalAddOrEditForm.tsx
+++ b/src/ui/proposal/ProposalAddOrEditForm.tsx
@@ -6,7 +6,7 @@ import {
 	TextArea,
 	TextAreaWithDiff,
 } from 'fds/components';
-import * as React from 'react';
+import React, { useCallback, useEffect } from 'react';
 
 import ReviewAnnotationForm from 'fontoxml-feedback/src/ReviewAnnotationForm';
 import { BusyState, RecoveryOption } from 'fontoxml-feedback/src/types';
@@ -45,12 +45,12 @@ function ProposalAddOrEditFormContent({
 
 	const originalText = reviewAnnotation.originalText;
 
-	const validate = React.useCallback(
+	const validate = useCallback(
 		(value) => validateProposedChangeField(value, originalText),
 		[originalText]
 	);
 
-	React.useEffect(() => {
+	useEffect(() => {
 		if (!isEditing) {
 			onFieldChange({
 				name: 'proposedChange',

--- a/src/ui/proposal/ProposalCardContent.tsx
+++ b/src/ui/proposal/ProposalCardContent.tsx
@@ -1,14 +1,13 @@
+import React, { useMemo } from 'react';
+
 import {
 	Block,
-	Button,
 	Diff,
 	Flex,
-	HorizontalSeparationLine,
+	HorizontalSeparationLine, 
 	Icon,
 	Label,
-} from 'fds/components';
-import * as React from 'react';
-
+} from 'fontoxml-design-system/src/components';
 import FeedbackContextType from 'fontoxml-feedback/src/FeedbackContextType';
 import ReviewAnnotationAcceptProposalButton from 'fontoxml-feedback/src/ReviewAnnotationAcceptProposalButton';
 import {
@@ -26,6 +25,7 @@ import LoadingStateMessage from '../shared/LoadingStateMessage';
 import TruncatedText from '../shared/TruncatedText';
 import { CARD_HEADER_HEIGHT } from './../constants';
 import ProposalAddOrEditForm from './ProposalAddOrEditForm';
+import ProposalReplyComponent from './ProposalReplyComponent';
 
 function ProposalCardContent({
 	context,
@@ -51,7 +51,7 @@ function ProposalCardContent({
 	onReplyRemove,
 	onProposalMerge,
 }) {
-	const hasReplyInNonIdleBusyState = React.useMemo(() => {
+	const hasReplyInNonIdleBusyState = useMemo(() => {
 		if (!reviewAnnotation.replies) {
 			return false;
 		}
@@ -304,13 +304,9 @@ function ProposalCardContent({
 
 						<Flex justifyContent="flex-end" spaceSize="l">
 							{showReplyButton && (
-								<Button
-									icon="far fa-reply"
-									isDisabled={
-										!!reviewAnnotation.error ||
-										reviewAnnotation.isLoading
-									}
-									onClick={onReplyAdd}
+								<ProposalReplyComponent
+									onReplyAdd={onReplyAdd}
+									reviewAnnotation={reviewAnnotation}
 								/>
 							)}
 

--- a/src/ui/proposal/ProposalCardContent.tsx
+++ b/src/ui/proposal/ProposalCardContent.tsx
@@ -4,7 +4,7 @@ import {
 	Block,
 	Diff,
 	Flex,
-	HorizontalSeparationLine, 
+	HorizontalSeparationLine,
 	Icon,
 	Label,
 } from 'fontoxml-design-system/src/components';

--- a/src/ui/proposal/ProposalCardFooter.tsx
+++ b/src/ui/proposal/ProposalCardFooter.tsx
@@ -9,7 +9,7 @@ function ProposalCardFooter({ onReplyAdd, reviewAnnotation }) {
 		(domNode: HTMLElement) => (textInputRef.current = domNode)
 	);
 
-    useEffect(() => {
+	useEffect(() => {
 		if (!textInputRef.current) {
 			return;
 		}
@@ -25,13 +25,13 @@ function ProposalCardFooter({ onReplyAdd, reviewAnnotation }) {
 	});
 
 	return (
-        <TextInput
-            onRef={handleTextInputRef}
-            isDisabled={
-                !!reviewAnnotation.error || reviewAnnotation.isLoading
-            }
-            placeholder={t('Type your reply')}
-        />
+		<TextInput
+			onRef={handleTextInputRef}
+			isDisabled={
+				!!reviewAnnotation.error || reviewAnnotation.isLoading
+			}
+			placeholder={t('Type your reply')}
+		/>
 	);
 }
 

--- a/src/ui/proposal/ProposalCardFooter.tsx
+++ b/src/ui/proposal/ProposalCardFooter.tsx
@@ -1,0 +1,38 @@
+import React, { useCallback, useRef, useEffect } from 'react';
+
+import { TextInput } from 'fontoxml-design-system/src/components';
+import t from 'fontoxml-localization/src/t';
+
+function ProposalCardFooter({ onReplyAdd, reviewAnnotation }) {
+	const textInputRef = useRef<HTMLElement>(null);
+	const handleTextInputRef = useCallback(
+		(domNode: HTMLElement) => (textInputRef.current = domNode)
+	);
+
+    useEffect(() => {
+		if (!textInputRef.current) {
+			return;
+		}
+
+		const handleFocus = () => {
+			onReplyAdd();
+		};
+
+		textInputRef.current.addEventListener('focus', handleFocus);
+		return () => {
+			textInputRef.current.removeEventListener('focus', handleFocus);
+		};
+	});
+
+	return (
+        <TextInput
+            onRef={handleTextInputRef}
+            isDisabled={
+                !!reviewAnnotation.error || reviewAnnotation.isLoading
+            }
+            placeholder={t('Type your reply')}
+        />
+	);
+}
+
+export default ProposalCardFooter;

--- a/src/ui/proposal/ProposalReplyComponent.tsx
+++ b/src/ui/proposal/ProposalReplyComponent.tsx
@@ -7,27 +7,27 @@ import t from 'fontoxml-localization/src/t';
 import ProposalCardFooter from "./ProposalCardFooter";
 
 function ProposalReplyComponent({ onReplyAdd, reviewAnnotation }) {
-    // Check if we are on the "/review" route.
+	// Check if we are on the "/review" route.
 	const { path } = useRouteMatch();
 	const isOnReviewRoute = path === '/review';
 
-    // If we are on the review route, we need to show the text input 
-    // to add the reply.
-    if (isOnReviewRoute) {
-        return (
-            <ProposalCardFooter onReplyAdd={onReplyAdd} reviewAnnotation={reviewAnnotation} />
-        );
-    }
+	// If we are on the review route, we need to show the text input 
+	// to add the reply.
+	if (isOnReviewRoute) {
+		return (
+			<ProposalCardFooter onReplyAdd={onReplyAdd} reviewAnnotation={reviewAnnotation} />
+		);
+	}
 
-    // Otherwise, a button for adding the reply will be shown.
-    return (
-        <Button
-            icon="far fa-reply"
-            isDisabled={!!reviewAnnotation.error || reviewAnnotation.isLoading}
-            label={t('Reply')}
-            onClick={onReplyAdd}
-        />
-    )
+	// Otherwise, a button for adding the reply will be shown.
+	return (
+		<Button
+			icon="far fa-reply"
+			isDisabled={!!reviewAnnotation.error || reviewAnnotation.isLoading}
+			label={t('Reply')}
+			onClick={onReplyAdd}
+		/>
+	);
 }
 
 export default ProposalReplyComponent;

--- a/src/ui/proposal/ProposalReplyComponent.tsx
+++ b/src/ui/proposal/ProposalReplyComponent.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { useRouteMatch } from 'react-router-dom';
+
+import { Button } from 'fontoxml-design-system/src/components';
+import t from 'fontoxml-localization/src/t';
+
+import ProposalCardFooter from "./ProposalCardFooter";
+
+function ProposalReplyComponent({ onReplyAdd, reviewAnnotation }) {
+    // Check if we are on the "/review" route.
+	const { path } = useRouteMatch();
+	const isOnReviewRoute = path === '/review';
+
+    // If we are on the review route, we need to show the text input 
+    // to add the reply.
+    if (isOnReviewRoute) {
+        return (
+            <ProposalCardFooter onReplyAdd={onReplyAdd} reviewAnnotation={reviewAnnotation} />
+        );
+    }
+
+    // Otherwise, a button for adding the reply will be shown.
+    return (
+        <Button
+            icon="far fa-reply"
+            isDisabled={!!reviewAnnotation.error || reviewAnnotation.isLoading}
+            label={t('Reply')}
+            onClick={onReplyAdd}
+        />
+    )
+}
+
+export default ProposalReplyComponent;


### PR DESCRIPTION
In this PR, I have added firstly an input field that is only shown in the review route when we want to reply. Then, we only show the Reply button, which has now a label set [here](https://github.com/FontoXML/fontoxml-review-reference-configuration/pull/24/files#diff-4fa171a94045df13268b5e89891979de560f569235396e9660e4651df9faf6e7R27), when we are on the editor route.

Note that I haven't had to change the existing E2E tests, as they didn't cover proposals replying, so for that reason, I have decided to create some E2E tests.