### PR TITLE
DEV-14728 DEP-107 Adapt to changes in type names and import locations

### DIFF
--- a/src/install.ts
+++ b/src/install.ts
@@ -12,7 +12,7 @@ import globalCommentsStackedIcons from './ui/global-comments-stacked-icons.svg';
 import MastheadForReview from './ui/MastheadForReview';
 import ProposalCardContent from './ui/proposal/ProposalCardContent';
 
-export default function install() {
+export default function install(): void {
 	registerTextRangeReviewAnnotationType('comment', {
 		icon: 'far fa-comment',
 		label: 'Comment',

--- a/src/ui/FilterForm.tsx
+++ b/src/ui/FilterForm.tsx
@@ -6,7 +6,7 @@ import {
 	Flex,
 	Label,
 } from 'fontoxml-design-system/src/components';
-import type { FormValueByName } from 'fontoxml-design-system/src/types';
+import type { FdsFormValueByName } from 'fontoxml-design-system/src/types';
 import type { ReviewFilterFormProps } from 'fontoxml-feedback/src/types';
 import t from 'fontoxml-localization/src/t';
 
@@ -14,7 +14,7 @@ import useNestedCheckboxesForFilterOptions from './useNestedCheckboxesForFilterO
 
 function determineParentFieldValue(
 	subFieldNames: string[],
-	valueByNameForUI: FormValueByName
+	valueByNameForUI: FdsFormValueByName
 ): boolean {
 	return subFieldNames.reduce<boolean>((value, subFieldName) => {
 		if (value === Checkbox.VALUE_INDETERMINATE) {

--- a/src/ui/comment/CommentAddOrEditForm.tsx
+++ b/src/ui/comment/CommentAddOrEditForm.tsx
@@ -9,22 +9,20 @@ import {
 	TextArea,
 } from 'fontoxml-design-system/src/components';
 import type {
-	FormFeedback,
-	FormValueByName,
+	FdsFormFeedback,
+	FdsFormValueByName,
 } from 'fontoxml-design-system/src/types';
 import ReviewAnnotationForm from 'fontoxml-feedback/src/ReviewAnnotationForm';
+import ReviewBusyState from 'fontoxml-feedback/src/ReviewBusyState';
+import ReviewRecoveryOption from 'fontoxml-feedback/src/ReviewRecoveryOption';
+import ReviewTargetType from 'fontoxml-feedback/src/ReviewTargetType';
 import type { ReviewCardContentComponentProps } from 'fontoxml-feedback/src/types';
-import {
-	ReviewBusyState,
-	ReviewRecoveryOption,
-	ReviewTargetType,
-} from 'fontoxml-feedback/src/types';
 import t from 'fontoxml-localization/src/t';
 
 import commentTypes from '../commentTypes';
 import AddOrEditFormFooter from '../shared/AddOrEditFormFooter';
 
-function validateCommentField(value: string): FormFeedback {
+function validateCommentField(value: string): FdsFormFeedback | null {
 	if (!value || value.trim() === '') {
 		return { connotation: 'error', message: 'Comment is required.' };
 	}
@@ -47,7 +45,7 @@ function CommentAddOrEditFormContent({
 	focusableRef: HTMLElement;
 	isSubmitDisabled: boolean;
 	onFieldChange(...args: unknown[]): void;
-	valueByName: FormValueByName;
+	valueByName: FdsFormValueByName;
 }) {
 	const error = reviewAnnotation.error || null;
 	const isDisabled =
@@ -70,7 +68,7 @@ function CommentAddOrEditFormContent({
 
 	const currentCommentType =
 		commentTypes.find(
-			(commentType) => commentType.value === valueByName['commentType']
+			(commentType) => commentType.value === valueByName.commentType
 		) || commentTypes[0];
 
 	let label = currentCommentType.label;
@@ -159,12 +157,7 @@ function CommentAddOrEditForm({
 			initialValueByName={reviewAnnotation.metadata}
 			onSubmit={onSubmit}
 		>
-			{({
-				isSubmitDisabled,
-				onFieldChange,
-				onSubmit,
-				valueByName,
-			}) => (
+			{({ isSubmitDisabled, onFieldChange, onSubmit, valueByName }) => (
 				<CommentAddOrEditFormContent
 					focusableRef={focusableRef}
 					isSubmitDisabled={isSubmitDisabled}

--- a/src/ui/comment/CommentCardContent.tsx
+++ b/src/ui/comment/CommentCardContent.tsx
@@ -7,12 +7,10 @@ import {
 	Label,
 } from 'fontoxml-design-system/src/components';
 import FeedbackContextType from 'fontoxml-feedback/src/FeedbackContextType';
+import ReviewAnnotationStatus from 'fontoxml-feedback/src/ReviewAnnotationStatus';
+import ReviewBusyState from 'fontoxml-feedback/src/ReviewBusyState';
+import ReviewRecoveryOption from 'fontoxml-feedback/src/ReviewRecoveryOption';
 import type { ReviewCardContentComponentProps } from 'fontoxml-feedback/src/types';
-import {
-	ReviewAnnotationStatus,
-	ReviewBusyState,
-	ReviewRecoveryOption,
-} from 'fontoxml-feedback/src/types';
 import t from 'fontoxml-localization/src/t';
 
 import commentTypes from '../commentTypes';

--- a/src/ui/proposal/ProposalAddOrEditForm.tsx
+++ b/src/ui/proposal/ProposalAddOrEditForm.tsx
@@ -8,13 +8,11 @@ import {
 	TextArea,
 	TextAreaWithDiff,
 } from 'fontoxml-design-system/src/components';
-import type { FormFeedback } from 'fontoxml-design-system/src/types';
+import type { FdsFormFeedback } from 'fontoxml-design-system/src/types';
 import ReviewAnnotationForm from 'fontoxml-feedback/src/ReviewAnnotationForm';
+import ReviewBusyState from 'fontoxml-feedback/src/ReviewBusyState';
+import ReviewRecoveryOption from 'fontoxml-feedback/src/ReviewRecoveryOption';
 import type { ReviewCardContentComponentProps } from 'fontoxml-feedback/src/types';
-import {
-	ReviewBusyState,
-	ReviewRecoveryOption,
-} from 'fontoxml-feedback/src/types';
 import t from 'fontoxml-localization/src/t';
 
 import AddOrEditFormFooter from '../shared/AddOrEditFormFooter';
@@ -22,7 +20,7 @@ import AddOrEditFormFooter from '../shared/AddOrEditFormFooter';
 function validateProposedChangeField(
 	value: string,
 	originalText: string
-): FormFeedback {
+): FdsFormFeedback {
 	if (value === originalText) {
 		return {
 			connotation: 'error',
@@ -39,10 +37,10 @@ function ProposalAddOrEditFormContent({
 	focusableRef,
 	isSubmitDisabled,
 	onFieldChange,
-	onCancel, 
-	onReviewAnnotationRefresh, 
-	onSubmit, 
-	reviewAnnotation, 
+	onCancel,
+	onReviewAnnotationRefresh,
+	onSubmit,
+	reviewAnnotation,
 }: Props & {
 	focusableRef: HTMLElement;
 	isSubmitDisabled: boolean;
@@ -153,11 +151,7 @@ function ProposalAddOrEditForm({
 			initialValueByName={reviewAnnotation.metadata}
 			onSubmit={onSubmit}
 		>
-			{({
-				isSubmitDisabled,
-				onFieldChange,
-				onSubmit,
-			}) => (
+			{({ isSubmitDisabled, onFieldChange, onSubmit }) => (
 				<ProposalAddOrEditFormContent
 					focusableRef={focusableRef}
 					isSubmitDisabled={isSubmitDisabled}

--- a/src/ui/proposal/ProposalCardContent.tsx
+++ b/src/ui/proposal/ProposalCardContent.tsx
@@ -10,12 +10,10 @@ import {
 } from 'fontoxml-design-system/src/components';
 import FeedbackContextType from 'fontoxml-feedback/src/FeedbackContextType';
 import ReviewAnnotationAcceptProposalButton from 'fontoxml-feedback/src/ReviewAnnotationAcceptProposalButton';
+import ReviewAnnotationStatus from 'fontoxml-feedback/src/ReviewAnnotationStatus';
+import ReviewBusyState from 'fontoxml-feedback/src/ReviewBusyState';
+import ReviewRecoveryOption from 'fontoxml-feedback/src/ReviewRecoveryOption';
 import type { ReviewCardContentComponentProps } from 'fontoxml-feedback/src/types';
-import {
-	ReviewAnnotationStatus,
-	ReviewBusyState,
-	ReviewRecoveryOption,
-} from 'fontoxml-feedback/src/types';
 import t from 'fontoxml-localization/src/t';
 
 import CardErrorFooter from '../shared/CardErrorFooter';

--- a/src/ui/shared/AddOrEditFormFooter.tsx
+++ b/src/ui/shared/AddOrEditFormFooter.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 
 import { Button, Flex } from 'fontoxml-design-system/src/components';
-import type { PaddingSize } from 'fontoxml-design-system/src/types';
+import type { FdsPaddingSize } from 'fontoxml-design-system/src/types';
 import ErrorToast from 'fontoxml-feedback/src/ErrorToast';
+import ReviewRecoveryOption from 'fontoxml-feedback/src/ReviewRecoveryOption';
 import type {
 	ReviewAnnotationError,
 	ReviewCardContentComponentProps,
 } from 'fontoxml-feedback/src/types';
-import { ReviewRecoveryOption } from 'fontoxml-feedback/src/types';
 import t from 'fontoxml-localization/src/t';
 
 import ResponsiveButtonSpacer from './ResponsiveButtonSpacer';
@@ -37,7 +37,7 @@ type Props = {
 	onSubmit: ReviewCardContentComponentProps['onReviewAnnotationFormSubmit'];
 };
 
-const paddingSize: PaddingSize = { top: 'l' };
+const paddingSize: FdsPaddingSize = { top: 'l' };
 
 function AddOrEditFormFooter({
 	error,

--- a/src/ui/shared/CardErrors.tsx
+++ b/src/ui/shared/CardErrors.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 
 import ErrorToast from 'fontoxml-feedback/src/ErrorToast';
+import ReviewBusyState from 'fontoxml-feedback/src/ReviewBusyState';
 import type { ReviewCardContentComponentProps } from 'fontoxml-feedback/src/types';
-import { ReviewBusyState } from 'fontoxml-feedback/src/types';
 
 type Props = {
 	onReviewAnnotationRefresh: ReviewCardContentComponentProps['onReviewAnnotationRefresh'];

--- a/src/ui/shared/CardHeader.tsx
+++ b/src/ui/shared/CardHeader.tsx
@@ -292,10 +292,10 @@ export default function CardHeader({
 			.displayLabel.toLowerCase();
 
 		return reviewAnnotation.type === 'proposal'
-			? t(`This proposal is {RESOLUTION}`, {
+			? t('This proposal is {RESOLUTION}', {
 					RESOLUTION: resolution,
 			  })
-			: t(`This comment is {RESOLUTION}`, {
+			: t('This comment is {RESOLUTION}', {
 					RESOLUTION: resolution,
 			  });
 	}, [reviewAnnotation]);

--- a/src/ui/shared/CardHeader.tsx
+++ b/src/ui/shared/CardHeader.tsx
@@ -14,15 +14,13 @@ import {
 } from 'fontoxml-design-system/src/components';
 import Badge from 'fontoxml-feedback/src/Badge';
 import FeedbackContextType from 'fontoxml-feedback/src/FeedbackContextType';
+import ReviewAnnotationStatus from 'fontoxml-feedback/src/ReviewAnnotationStatus';
+import ReviewBusyState from 'fontoxml-feedback/src/ReviewBusyState';
+import ReviewRecoveryOption from 'fontoxml-feedback/src/ReviewRecoveryOption';
+import ReviewTargetType from 'fontoxml-feedback/src/ReviewTargetType';
 import type {
 	ReviewAnnotationError,
 	ReviewCardContentComponentProps,
-} from 'fontoxml-feedback/src/types';
-import {
-	ReviewAnnotationStatus,
-	ReviewBusyState,
-	ReviewRecoveryOption,
-	ReviewTargetType,
 } from 'fontoxml-feedback/src/types';
 import t from 'fontoxml-localization/src/t';
 

--- a/src/ui/shared/CardRepliesAndResolution.tsx
+++ b/src/ui/shared/CardRepliesAndResolution.tsx
@@ -7,11 +7,9 @@ import {
 	Icon,
 } from 'fontoxml-design-system/src/components';
 import FeedbackContextType from 'fontoxml-feedback/src/FeedbackContextType';
+import ReviewAnnotationStatus from 'fontoxml-feedback/src/ReviewAnnotationStatus';
+import ReviewBusyState from 'fontoxml-feedback/src/ReviewBusyState';
 import type { ReviewCardContentComponentProps } from 'fontoxml-feedback/src/types';
-import {
-	ReviewAnnotationStatus,
-	ReviewBusyState,
-} from 'fontoxml-feedback/src/types';
 
 import AuthorAndTimestampLabel from '../AuthorAndTimestampLabel';
 import resolutions from '../feedbackResolutions';

--- a/src/ui/shared/ErrorStateMessage.tsx
+++ b/src/ui/shared/ErrorStateMessage.tsx
@@ -5,11 +5,11 @@ import {
 	CompactStateMessage,
 	Flex,
 } from 'fontoxml-design-system/src/components';
+import ReviewRecoveryOption from 'fontoxml-feedback/src/ReviewRecoveryOption';
 import type {
 	ReviewAnnotationError,
 	ReviewCardContentComponentProps,
 } from 'fontoxml-feedback/src/types';
-import { ReviewRecoveryOption } from 'fontoxml-feedback/src/types';
 import t from 'fontoxml-localization/src/t';
 
 const iconByConnotation = {

--- a/src/ui/shared/LoadingStateMessage.tsx
+++ b/src/ui/shared/LoadingStateMessage.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 
 import { CompactStateMessage } from 'fontoxml-design-system/src/components';
-import type { Message } from 'fontoxml-design-system/src/types';
+import type { FdsMessage } from 'fontoxml-design-system/src/types';
 
 type Props = {
-	message: Message;
+	message: FdsMessage;
 };
 
 function LoadingStateMessage({ message }: Props) {

--- a/src/ui/shared/Replies.tsx
+++ b/src/ui/shared/Replies.tsx
@@ -5,8 +5,8 @@ import {
 	CompactStateMessage,
 	HorizontalSeparationLine,
 } from 'fontoxml-design-system/src/components';
+import ReviewBusyState from 'fontoxml-feedback/src/ReviewBusyState';
 import type { ReviewCardContentComponentProps } from 'fontoxml-feedback/src/types';
-import { ReviewBusyState } from 'fontoxml-feedback/src/types';
 import t from 'fontoxml-localization/src/t';
 
 import Reply from './Reply';

--- a/src/ui/shared/Reply.tsx
+++ b/src/ui/shared/Reply.tsx
@@ -10,11 +10,11 @@ import {
 	Label,
 } from 'fontoxml-design-system/src/components';
 import ErrorToast from 'fontoxml-feedback/src/ErrorToast';
+import ReviewBusyState from 'fontoxml-feedback/src/ReviewBusyState';
 import type {
 	ReviewCardContentComponentProps,
 	ReviewReply,
 } from 'fontoxml-feedback/src/types';
-import { ReviewBusyState } from 'fontoxml-feedback/src/types';
 import t from 'fontoxml-localization/src/t';
 
 import AuthorAndTimestampLabel from '../AuthorAndTimestampLabel';

--- a/src/ui/shared/ReplyForm.tsx
+++ b/src/ui/shared/ReplyForm.tsx
@@ -8,17 +8,15 @@ import {
 	Icon,
 	TextArea,
 } from 'fontoxml-design-system/src/components';
-import type { FormFeedback } from 'fontoxml-design-system/src/types';
+import type { FdsFormFeedback } from 'fontoxml-design-system/src/types';
 import ErrorToast from 'fontoxml-feedback/src/ErrorToast';
 import ReviewAnnotationForm from 'fontoxml-feedback/src/ReviewAnnotationForm';
+import ReviewBusyState from 'fontoxml-feedback/src/ReviewBusyState';
+import ReviewRecoveryOption from 'fontoxml-feedback/src/ReviewRecoveryOption';
 import type {
 	ReviewAnnotationError,
 	ReviewCardContentComponentProps,
 	ReviewReply,
-} from 'fontoxml-feedback/src/types';
-import {
-	ReviewBusyState,
-	ReviewRecoveryOption,
 } from 'fontoxml-feedback/src/types';
 import t from 'fontoxml-localization/src/t';
 
@@ -62,7 +60,7 @@ function determineSaveButtonLabel(
 
 const rows = { minimum: 2, maximum: 6 };
 
-function validateReplyField(value: string): FormFeedback {
+function validateReplyField(value: string): FdsFormFeedback | null {
 	if (!value || value.trim() === '') {
 		return { connotation: 'error', message: 'Reply is required.' };
 	}
@@ -73,11 +71,11 @@ function validateReplyField(value: string): FormFeedback {
 function ReplyFormContent({
 	focusableRef,
 	isSubmitDisabled,
-	onCancelButtonClick, 
-	onHideLinkClick, 
-	onRefreshLinkClick, 
-	onSubmit, 
-	reply, 
+	onCancelButtonClick,
+	onHideLinkClick,
+	onRefreshLinkClick,
+	onSubmit,
+	reply,
 }: {
 	focusableRef: HTMLElement;
 	isSubmitDisabled: boolean;
@@ -176,7 +174,7 @@ function ReplyForm({
 	onHide,
 	onRefresh,
 	onSubmit,
-	reply
+	reply,
 }: Props) {
 	const handleHideLinkClick = React.useCallback(() => {
 		onHide(reply.id);

--- a/src/ui/shared/ResolveForm.tsx
+++ b/src/ui/shared/ResolveForm.tsx
@@ -13,21 +13,19 @@ import {
 	Toast,
 } from 'fontoxml-design-system/src/components';
 import type {
-	FormFeedback,
-	FormValueByName,
+	FdsFormFeedback,
+	FdsFormValueByName,
 } from 'fontoxml-design-system/src/types';
 import ErrorToast from 'fontoxml-feedback/src/ErrorToast';
 import FeedbackContextType from 'fontoxml-feedback/src/FeedbackContextType';
 import ReviewAnnotationAcceptProposalButton from 'fontoxml-feedback/src/ReviewAnnotationAcceptProposalButton';
 import ReviewAnnotationForm from 'fontoxml-feedback/src/ReviewAnnotationForm';
+import ReviewAnnotationStatus from 'fontoxml-feedback/src/ReviewAnnotationStatus';
+import ReviewProposalState from 'fontoxml-feedback/src/ReviewProposalState';
+import ReviewRecoveryOption from 'fontoxml-feedback/src/ReviewRecoveryOption';
 import type {
 	ReviewAnnotationError,
 	ReviewCardContentComponentProps,
-} from 'fontoxml-feedback/src/types';
-import {
-	ReviewAnnotationStatus,
-	ReviewProposalState,
-	ReviewRecoveryOption,
 } from 'fontoxml-feedback/src/types';
 import t from 'fontoxml-localization/src/t';
 
@@ -51,7 +49,7 @@ function determineSaveButtonLabel(
 		: t('Resolve');
 }
 
-function validateResolutionField(value: unknown): FormFeedback {
+function validateResolutionField(value: unknown): FdsFormFeedback | null {
 	if (!value) {
 		return { connotation: 'error', message: 'Resolution is required.' };
 	}
@@ -72,7 +70,7 @@ function ResolveFormContent({
 }: Props & {
 	isSubmitDisabled: boolean;
 	onFocusableRef(): void;
-	valueByName: FormValueByName;
+	valueByName: FdsFormValueByName;
 }) {
 	const error = reviewAnnotation.error ? reviewAnnotation.error : null;
 	const isDisabled =
@@ -236,7 +234,7 @@ type Props = {
 	onCancel: ReviewCardContentComponentProps['onReviewAnnotationFormCancel'];
 	onProposalMerge: ReviewCardContentComponentProps['onProposalMerge'];
 	onReviewAnnotationRefresh: ReviewCardContentComponentProps['onReviewAnnotationRefresh'];
-	onSubmit(valueByName: FormValueByName): void;
+	onSubmit(valueByName: FdsFormValueByName): void;
 };
 
 const ResolveForm: React.FC<Props> = ({

--- a/src/ui/useAuthorAndTimestampLabel.tsx
+++ b/src/ui/useAuthorAndTimestampLabel.tsx
@@ -11,17 +11,19 @@ import t from 'fontoxml-localization/src/t';
 const configuredScope = configurationManager.get('scope');
 
 /**
- * A custom React hook that formats the author and timestamp of the given reviewAnnotation or reply.
+ * A custom React hook that formats the author and timestamp of the given
+ * reviewAnnotation or reply.
  *
- * Renders the author name as "You" if the author id matches the current scope user id.
+ * Renders the author name as "You" if the author id matches the current scope
+ * user id.
  *
  * The timestamp label will not contain any kind of dashes.
  *
- * @param reviewAnnotationOrReply               -
- * @param [isReviewAnnotationResolved=false]    - If set to true it uses the resolvedAuthor and
- * resolvedTimestamp fields of the given reviewAnnotation, otherwise it uses the (created) author
- * and timestamp fields.
- * @param  [fallback=t('Author not available')] - A string to display when the (resolved)
+ * @param reviewAnnotationOrReply    -
+ * @param isReviewAnnotationResolved - If set to true it uses the resolvedAuthor
+ * and resolvedTimestamp fields of the given reviewAnnotation, otherwise it uses
+ * the (created) author and timestamp fields.
+ * @param fallback                   - A string to display when the (resolved)
  * author field is not set on the given reviewAnnotationOrReply.
  *
  * @returns Object containing the 'author' and the 'timestamp' keys.

--- a/src/ui/useAuthorAndTimestampLabel.tsx
+++ b/src/ui/useAuthorAndTimestampLabel.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 
 import configurationManager from 'fontoxml-configuration/src/configurationManager';
+import ReviewBusyState from 'fontoxml-feedback/src/ReviewBusyState';
 import type {
 	ReviewCardContentComponentProps,
 	ReviewReply,
 } from 'fontoxml-feedback/src/types';
-import { ReviewBusyState } from 'fontoxml-feedback/src/types';
 import t from 'fontoxml-localization/src/t';
 
 const configuredScope = configurationManager.get('scope');

--- a/src/ui/useNestedCheckboxesForFilterOptions.ts
+++ b/src/ui/useNestedCheckboxesForFilterOptions.ts
@@ -1,10 +1,10 @@
 import * as React from 'react';
 
 import { Checkbox } from 'fontoxml-design-system/src/components';
-import type { FormValueByName } from 'fontoxml-design-system/src/types';
+import type { FdsFormValueByName } from 'fontoxml-design-system/src/types';
 
 function useNestedCheckboxesForFilterOptions(
-	valueByName: FormValueByName,
+	valueByName: FdsFormValueByName,
 	onFieldsChange: (...args: unknown[]) => void
 ) {
 	// This hook automatically updates parent/child checkboxes, including the


### PR DESCRIPTION
This updates some FDS types to their now public import locations / names, and updates fontoxml-feedback enum imports (again) to their new locations. 

Merging should wait until the corresponding PR in fontoxml-feedback lands, which is waiting for approval of DEP-107.