### PR TITLE
DEV-15040 Add tooltip to the proposal reply button

### DIFF
--- a/src/ui/proposal/ProposalReplyComponent.tsx
+++ b/src/ui/proposal/ProposalReplyComponent.tsx
@@ -35,6 +35,7 @@ function ProposalReplyComponent({ onReplyAdd, reviewAnnotation }: Props) {
 			isDisabled={!!reviewAnnotation.error || reviewAnnotation.isLoading}
 			label={t('Reply')}
 			onClick={onReplyAdd}
+			tooltipContent={t('Reply to the proposed change.')}
 		/>
 	);
 }


### PR DESCRIPTION
Kevin and I agreed the text to display. The other option was "Reply with a comment to the proposed change."