### PR TITLE
DEV-12025 registers test annotation type

### DIFF
--- a/src/install.ts
+++ b/src/install.ts
@@ -23,6 +23,18 @@ export default function install(): void {
 		osxKeyBinding: 'cmd+alt+m',
 	});
 
+	// This is a test annotation type that is only enabled for a specific document.
+	registerTextRangeReviewAnnotationType('enabled-selector-comment', {
+		enabledSelector: 'fonto:document(fonto:remote-document-id(fonto:selection-common-ancestor()))/*[1]/@id = "topic_915c9f1b-ee2a-4853-d8f2-5fffaa9ab116"',
+		icon: 'far fa-comment',
+		label: 'EnabledSelector comment',
+		priority: -1,
+		CardContentComponent: CommentCardContent,
+		tooltipContent: t('Add test comment to selected text.'),
+		keyBinding: 'ctrl+alt+m',
+		osxKeyBinding: 'cmd+alt+m',
+	});
+
 	registerObjectReviewAnnotationType('object-comment', {
 		// Use a fancier selector here and/or register multiple different object annotation types.
 		enabledSelector: 'self::image',

--- a/src/install.ts
+++ b/src/install.ts
@@ -25,7 +25,7 @@ export default function install(): void {
 
 	// This is a test annotation type that is only enabled for a specific document.
 	registerTextRangeReviewAnnotationType('enabled-selector-comment', {
-		enabledSelector: 'fonto:document(fonto:remote-document-id(fonto:selection-common-ancestor()))/*[1]/@id = "topic_915c9f1b-ee2a-4853-d8f2-5fffaa9ab116"',
+		enabledSelector: 'fonto:remote-document-id(fonto:selection-common-ancestor())/*[1]/@id = "clogs/sample.xml"',
 		icon: 'far fa-comment',
 		label: 'EnabledSelector comment',
 		priority: -1,
@@ -76,7 +76,7 @@ export default function install(): void {
 
 	// Review annotation type for testing the enabledSelector option.
 	registerPublicationReviewAnnotationType('enabled-selector-publication-comment', {
-		enabledSelector: 'fonto:document(fonto:remote-document-id(fonto:selection-common-ancestor()))/*[1]/@id = "topic_915c9f1b-ee2a-4853-d8f2-5fffaa9ab116"',
+		enabledSelector: 'fonto:remote-document-id(fonto:selection-common-ancestor())/*[1]/@id = "clogs/sample.xml"',
 		icon: 'global-comments-stacked-icons',
 		label: 'EnabledSelector Global comment',
 		priority: -2,

--- a/src/install.ts
+++ b/src/install.ts
@@ -25,7 +25,7 @@ export default function install(): void {
 
 	// This is a test annotation type that is only enabled for a specific document.
 	registerTextRangeReviewAnnotationType('enabled-selector-comment', {
-		enabledSelector: 'fonto:remote-document-id(fonto:selection-common-ancestor())/*[1]/@id = "clogs/sample.xml"',
+		enabledSelector: 'fonto:remote-document-id(fonto:selection-common-ancestor()) = "clogs/sample.xml"',
 		icon: 'far fa-comment',
 		label: 'EnabledSelector comment',
 		priority: -1,
@@ -76,7 +76,7 @@ export default function install(): void {
 
 	// Review annotation type for testing the enabledSelector option.
 	registerPublicationReviewAnnotationType('enabled-selector-publication-comment', {
-		enabledSelector: 'fonto:remote-document-id(fonto:selection-common-ancestor())/*[1]/@id = "clogs/sample.xml"',
+		enabledSelector: 'fonto:remote-document-id(fonto:selection-common-ancestor()) = "clogs/sample.xml"',
 		icon: 'global-comments-stacked-icons',
 		label: 'EnabledSelector Global comment',
 		priority: -2,

--- a/src/install.ts
+++ b/src/install.ts
@@ -21,6 +21,7 @@ export default function install(): void {
 		tooltipContent: t('Add comment to selected text.'),
 		keyBinding: 'ctrl+alt+m',
 		osxKeyBinding: 'cmd+alt+m',
+		enabledSelector: 'not fonto:remote-document-id(fonto:selection-common-ancestor()) = "clogs/allannotationsdisabled.xml"',
 	});
 
 	// This is a test annotation type that is only enabled for a specific document.
@@ -60,6 +61,7 @@ export default function install(): void {
 		tooltipContent: t('Propose a change to selected text.'),
 		keyBinding: 'ctrl+alt+e',
 		osxKeyBinding: 'cmd+alt+e',
+		enabledSelector: 'not fonto:remote-document-id(fonto:selection-common-ancestor()) = "clogs/allannotationsdisabled.xml"',
 	});
 
 	registerPublicationReviewAnnotationType('publication-comment', {
@@ -72,6 +74,7 @@ export default function install(): void {
 		),
 		keyBinding: 'ctrl+alt+g',
 		osxKeyBinding: 'cmd+alt+g',
+		enabledSelector: 'not fonto:remote-document-id(fonto:selection-common-ancestor()) = "clogs/allannotationsdisabled.xml"',
 	});
 
 	// Review annotation type for testing the enabledSelector option.

--- a/src/install.ts
+++ b/src/install.ts
@@ -31,8 +31,8 @@ export default function install(): void {
 		priority: -1,
 		CardContentComponent: CommentCardContent,
 		tooltipContent: t('Add test comment to selected text.'),
-		keyBinding: 'ctrl+alt+m',
-		osxKeyBinding: 'cmd+alt+m',
+		keyBinding: 'ctrl+alt+shift+m',
+		osxKeyBinding: 'cmd+alt+shift+m',
 	});
 
 	registerObjectReviewAnnotationType('object-comment', {
@@ -72,6 +72,20 @@ export default function install(): void {
 		),
 		keyBinding: 'ctrl+alt+g',
 		osxKeyBinding: 'cmd+alt+g',
+	});
+
+	// Review annotation type for testing the enabledSelector option.
+	registerPublicationReviewAnnotationType('enabled-selector-publication-comment', {
+		enabledSelector: 'fonto:document(fonto:remote-document-id(fonto:selection-common-ancestor()))/*[1]/@id = "topic_915c9f1b-ee2a-4853-d8f2-5fffaa9ab116"',
+		icon: 'global-comments-stacked-icons',
+		label: 'EnabledSelector Global comment',
+		priority: -2,
+		CardContentComponent: CommentCardContent,
+		tooltipContent: t(
+			'Add a test comment that applies to the entire publication.'
+		),
+		keyBinding: 'ctrl+alt+shift+g',
+		osxKeyBinding: 'cmd+alt+shift+g',
 	});
 
 	configureReviewFilters({

--- a/src/install.ts
+++ b/src/install.ts
@@ -21,7 +21,7 @@ export default function install(): void {
 		tooltipContent: t('Add comment to selected text.'),
 		keyBinding: 'ctrl+alt+m',
 		osxKeyBinding: 'cmd+alt+m',
-		enabledSelector: 'not fonto:remote-document-id(fonto:selection-common-ancestor()) = "clogs/allannotationsdisabled.xml"',
+		enabledSelector: 'not(fonto:remote-document-id(fonto:selection-common-ancestor()) = "clogs/allannotationsdisabled.xml")',
 	});
 
 	// This is a test annotation type that is only enabled for a specific document.
@@ -61,7 +61,7 @@ export default function install(): void {
 		tooltipContent: t('Propose a change to selected text.'),
 		keyBinding: 'ctrl+alt+e',
 		osxKeyBinding: 'cmd+alt+e',
-		enabledSelector: 'not fonto:remote-document-id(fonto:selection-common-ancestor()) = "clogs/allannotationsdisabled.xml"',
+		enabledSelector: 'not(fonto:remote-document-id(fonto:selection-common-ancestor()) = "clogs/allannotationsdisabled.xml")',
 	});
 
 	registerPublicationReviewAnnotationType('publication-comment', {
@@ -74,7 +74,7 @@ export default function install(): void {
 		),
 		keyBinding: 'ctrl+alt+g',
 		osxKeyBinding: 'cmd+alt+g',
-		enabledSelector: 'not fonto:remote-document-id(fonto:selection-common-ancestor()) = "clogs/allannotationsdisabled.xml"',
+		enabledSelector: 'not(fonto:remote-document-id(fonto:selection-common-ancestor()) = "clogs/allannotationsdisabled.xml")',
 	});
 
 	// Review annotation type for testing the enabledSelector option.


### PR DESCRIPTION
Registers a annotation type useful to test the new functionality implemented on [DEV-12025](https://fontoxml.atlassian.net/browse/DEV-12025)