### PR TITLE
DEV-24561 DEV-24562 Multiple navigators support

### DIFF
--- a/src/REVIEW_NAVIGATOR_ID.ts
+++ b/src/REVIEW_NAVIGATOR_ID.ts
@@ -1,0 +1,3 @@
+// TODO: change this and update a bunch of e2e tests... :(
+const REVIEW_NAVIGATOR_ID = 'fontoxml-feedback';
+export default REVIEW_NAVIGATOR_ID;

--- a/src/install.ts
+++ b/src/install.ts
@@ -1,19 +1,53 @@
-import configureReviewFilters from 'fontoxml-feedback/src/configureReviewFilters';
 import registerObjectReviewAnnotationType from 'fontoxml-feedback/src/registerObjectReviewAnnotationType';
 import registerPublicationReviewAnnotationType from 'fontoxml-feedback/src/registerPublicationReviewAnnotationType';
+import registerReviewNavigator from 'fontoxml-feedback/src/registerReviewNavigator';
 import registerTextRangeReviewAnnotationType from 'fontoxml-feedback/src/registerTextRangeReviewAnnotationType';
 import t from 'fontoxml-localization/src/t';
 import uiManager from 'fontoxml-modular-ui/src/uiManager';
 
 import CommentCardContent from './ui/comment/CommentCardContent';
+import CommentsAndProposalsReviewNavigatorContent from './ui/CommentsAndProposalsReviewNavigatorContent';
 import FilterForm from './ui/FilterForm';
 import FilterFormSummaryChips from './ui/FilterFormSummaryChips';
 import globalCommentsStackedIcons from './ui/global-comments-stacked-icons.svg';
 import MastheadForReview from './ui/MastheadForReview';
 import ProposalCardContent from './ui/proposal/ProposalCardContent';
 
+const REVIEW_NAVIGATOR_ID = 'comments-and-proposals';
+
 export default function install(): void {
+	registerReviewNavigator(REVIEW_NAVIGATOR_ID, {
+		annotationsInitiallyVisibleIn: ['editor', 'review'],
+
+		filterConfiguration: {
+			FormComponent: FilterForm,
+			FormSummaryComponent: FilterFormSummaryChips,
+			initialFilterStateForEditor: { resolutionUnresolved: true },
+			initialFilterStateForReview: { resolutionUnresolved: true },
+		},
+
+		icon: 'far fa-comment',
+		ariaLabel: t('Comments'),
+		selectedTooltipContent: t('Close comments navigator'),
+		tooltipContent: t('Open comments navigator'),
+
+		hasPendingJumpOverlayJumpButtonLabel: t('Jump to comment'),
+		hasPendingJumpOverlayMessage: t(
+			'Comment found. To view the comment, click the button below.'
+		),
+		hasPendingJumpOverlayTitle: t('Comment found'),
+		isLoadingOverlayAutoJumpCheckboxLabel: t('Auto-jump to comment'),
+		isLoadingOverlayFirstMessage: t('Finding the next comment...'),
+
+		noAnnotationsFoundNotificationTitle: t('No comments found'),
+
+		NavigatorContentComponent: CommentsAndProposalsReviewNavigatorContent,
+	});
+
 	registerTextRangeReviewAnnotationType('comment', {
+		navigatorId: REVIEW_NAVIGATOR_ID,
+		enabledSelector:
+			'exists(fonto:selection-common-ancestor()) and not(fonto:remote-document-id(fonto:selection-common-ancestor()) = "clogs/allannotationsdisabled.xml")',
 		icon: 'far fa-comment',
 		label: 'Comment',
 		priority: 3,
@@ -21,12 +55,13 @@ export default function install(): void {
 		tooltipContent: t('Add comment to selected text.'),
 		keyBinding: 'ctrl+alt+m',
 		osxKeyBinding: 'cmd+alt+m',
-		enabledSelector: 'exists(fonto:selection-common-ancestor()) and not(fonto:remote-document-id(fonto:selection-common-ancestor()) = "clogs/allannotationsdisabled.xml")',
 	});
 
 	// This is a test annotation type that is only enabled for a specific document.
 	registerTextRangeReviewAnnotationType('enabled-selector-comment', {
-		enabledSelector: 'exists(fonto:selection-common-ancestor()) and fonto:remote-document-id(fonto:selection-common-ancestor()) = "clogs/sample.xml"',
+		navigatorId: REVIEW_NAVIGATOR_ID,
+		enabledSelector:
+			'exists(fonto:selection-common-ancestor()) and fonto:remote-document-id(fonto:selection-common-ancestor()) = "clogs/sample.xml"',
 		icon: 'far fa-comment',
 		label: 'EnabledSelector comment',
 		priority: -1,
@@ -37,6 +72,7 @@ export default function install(): void {
 	});
 
 	registerObjectReviewAnnotationType('object-comment', {
+		navigatorId: REVIEW_NAVIGATOR_ID,
 		// Use a fancier selector here and/or register multiple different object annotation types.
 		enabledSelector: 'self::image',
 		// This has the same name and icon as the 'comment' text range annotation.
@@ -54,6 +90,9 @@ export default function install(): void {
 	});
 
 	registerTextRangeReviewAnnotationType('proposal', {
+		navigatorId: REVIEW_NAVIGATOR_ID,
+		enabledSelector:
+			'exists(fonto:selection-common-ancestor()) and not(fonto:remote-document-id(fonto:selection-common-ancestor()) = "clogs/allannotationsdisabled.xml")',
 		icon: 'far fa-edit',
 		label: 'Proposal',
 		priority: 2,
@@ -61,10 +100,12 @@ export default function install(): void {
 		tooltipContent: t('Propose a change to selected text.'),
 		keyBinding: 'ctrl+alt+e',
 		osxKeyBinding: 'cmd+alt+e',
-		enabledSelector: 'exists(fonto:selection-common-ancestor()) and not(fonto:remote-document-id(fonto:selection-common-ancestor()) = "clogs/allannotationsdisabled.xml")',
 	});
 
 	registerPublicationReviewAnnotationType('publication-comment', {
+		navigatorId: REVIEW_NAVIGATOR_ID,
+		enabledSelector:
+			'exists(fonto:selection-common-ancestor()) and not(fonto:remote-document-id(fonto:selection-common-ancestor()) = "clogs/allannotationsdisabled.xml")',
 		icon: 'global-comments-stacked-icons',
 		label: 'Global comment',
 		priority: 1,
@@ -74,29 +115,26 @@ export default function install(): void {
 		),
 		keyBinding: 'ctrl+alt+g',
 		osxKeyBinding: 'cmd+alt+g',
-		enabledSelector: 'exists(fonto:selection-common-ancestor()) and not(fonto:remote-document-id(fonto:selection-common-ancestor()) = "clogs/allannotationsdisabled.xml")',
 	});
 
 	// Review annotation type for testing the enabledSelector option.
-	registerPublicationReviewAnnotationType('enabled-selector-publication-comment', {
-		enabledSelector: 'exists(fonto:selection-common-ancestor()) and fonto:remote-document-id(fonto:selection-common-ancestor()) = "clogs/sample.xml"',
-		icon: 'global-comments-stacked-icons',
-		label: 'EnabledSelector Global comment',
-		priority: -2,
-		CardContentComponent: CommentCardContent,
-		tooltipContent: t(
-			'Add a test comment that applies to the entire publication.'
-		),
-		keyBinding: 'ctrl+alt+shift+g',
-		osxKeyBinding: 'cmd+alt+shift+g',
-	});
-
-	configureReviewFilters({
-		FormComponent: FilterForm,
-		FormSummaryComponent: FilterFormSummaryChips,
-		initialFilterStateForEditor: { resolutionUnresolved: true },
-		initialFilterStateForReview: { resolutionUnresolved: true }
-	});
+	registerPublicationReviewAnnotationType(
+		'enabled-selector-publication-comment',
+		{
+			navigatorId: REVIEW_NAVIGATOR_ID,
+			enabledSelector:
+				'exists(fonto:selection-common-ancestor()) and fonto:remote-document-id(fonto:selection-common-ancestor()) = "clogs/sample.xml"',
+			icon: 'global-comments-stacked-icons',
+			label: 'EnabledSelector Global comment',
+			priority: -2,
+			CardContentComponent: CommentCardContent,
+			tooltipContent: t(
+				'Add a test comment that applies to the entire publication.'
+			),
+			keyBinding: 'ctrl+alt+shift+g',
+			osxKeyBinding: 'cmd+alt+shift+g',
+		}
+	);
 
 	uiManager.registerReactComponent('MastheadForReview', MastheadForReview);
 

--- a/src/ui/CommentsAndProposalsReviewNavigatorContent.tsx
+++ b/src/ui/CommentsAndProposalsReviewNavigatorContent.tsx
@@ -1,0 +1,130 @@
+import type { FC } from 'react';
+import { useMemo } from 'react';
+
+import { Block, Flex, Text } from 'fontoxml-design-system/src/components';
+import type {
+	FdsJustifyContent,
+	FdsPaddingSize,
+} from 'fontoxml-design-system/src/types';
+import NavigatorBatchShareButton from 'fontoxml-feedback/src/NavigatorBatchShareButton';
+import NavigatorFilterFormSummary from 'fontoxml-feedback/src/NavigatorFilterFormSummary';
+import NavigatorHeading from 'fontoxml-feedback/src/NavigatorHeading';
+import NavigatorShowBalloonsCheckbox from 'fontoxml-feedback/src/NavigatorShowBalloonsCheckbox';
+import NavigatorStateIndicators from 'fontoxml-feedback/src/NavigatorStateIndicators';
+import NavigatorToolbar from 'fontoxml-feedback/src/NavigatorToolbar';
+import type { ReviewNavigatorContentProps } from 'fontoxml-feedback/src/types';
+import t from 'fontoxml-localization/src/t';
+
+const topContainerPaddingSize: FdsPaddingSize = { top: 'l', horizontal: 'l' };
+
+const NavigatorToolbarWithMessages = () => (
+	<NavigatorToolbar
+		dataTestId="feedback-navigator-toolbar"
+		filterDropButtonAriaLabel={t('Filter comments')}
+		filterDropButtonTooltipContent={t('Filter comments')}
+		insertButtonAriaLabel={t('Add comment')}
+		insertButtonIsDisabledTooltipContent={t(
+			'Cannot create a comment right now. Your selection might be invalid or creating comments is not allowed.'
+		)}
+		insertButtonTooltipContent={t('Create comment')}
+		nextButtonTooltipContent={t('Navigate to the next comment')}
+		previousButtonTooltipContent={t('Navigate to the previous comment')}
+	/>
+);
+
+const NavigatorStateIndicatorsWithMessages: FC<{ withPadding: boolean }> = ({
+	withPadding,
+}) => (
+	<NavigatorStateIndicators
+		multipleErroredBalloonsMessage={t('Some comments could not be loaded')}
+		openFormsSingleLinkTooltipContent={t('Navigate to the unsaved comment')}
+		openFormsNextLinkTooltipContent={t(
+			'Navigate to the next unsaved comment'
+		)}
+		openFormsFirstLinkTooltipContent={t(
+			'Navigate to the first unsaved comment'
+		)}
+		renderOpenFormsMessage={(openFormsCount) =>
+			t(
+				'You have {UNSAVED_COMMENTS_COUNT, plural, one {1 unsaved comment} other {# unsaved comments}}.',
+				{ UNSAVED_COMMENTS_COUNT: openFormsCount }
+			)
+		}
+		withPadding={withPadding}
+	/>
+);
+
+const CommentsAndProposalsReviewNavigatorContent: FC<
+	ReviewNavigatorContentProps
+> = ({ balloonsAreVisible, isExpanded }) => {
+	const bottomContainerJustifyContent = useMemo<FdsJustifyContent>(
+		() => (balloonsAreVisible ? 'space-between' : 'flex-end'),
+		[balloonsAreVisible]
+	);
+	const bottomContainerPaddingSize = useMemo<FdsPaddingSize>(
+		() => ({
+			top: balloonsAreVisible ? 'l' : 'm',
+			horizontal: 'l',
+		}),
+		[balloonsAreVisible]
+	);
+
+	if (!isExpanded) {
+		return (
+			<>
+				<NavigatorToolbarWithMessages />
+				<NavigatorStateIndicatorsWithMessages withPadding={true} />
+			</>
+		);
+	}
+
+	return (
+		<>
+			<NavigatorToolbarWithMessages />
+
+			<Block
+				dataTestId="comments-and-proposals-navigator-content-top-container"
+				paddingSize={topContainerPaddingSize}
+			>
+				<NavigatorHeading heading={t('Comments')} />
+
+				{balloonsAreVisible && (
+					<>
+						<NavigatorStateIndicatorsWithMessages
+							withPadding={false}
+						/>
+
+						<NavigatorFilterFormSummary />
+					</>
+				)}
+				{!balloonsAreVisible && (
+					<Text>
+						{t('Show comments to use the navigation arrows.')}
+					</Text>
+				)}
+			</Block>
+
+			<Flex
+				alignItems="center"
+				dataTestId="comments-and-proposals-navigator-content-bottom-container"
+				flexDirection="row"
+				justifyContent={bottomContainerJustifyContent}
+				paddingSize={bottomContainerPaddingSize}
+			>
+				<NavigatorShowBalloonsCheckbox
+					label={t('Show comment balloons')}
+				/>
+
+				{balloonsAreVisible && (
+					<NavigatorBatchShareButton
+						globalAnnotationHeader={t('Global comments')}
+						modalTitle={t('Sharing comments')}
+						tooltipContent={t('Share multiple private comments')}
+					/>
+				)}
+			</Flex>
+		</>
+	);
+};
+
+export default CommentsAndProposalsReviewNavigatorContent;


### PR DESCRIPTION
Finish configuring the default review navigator
(id: REVIEW_NAVIGATOR_ID aka "fontoxml-feedback")

First configure review filters, then register the
annotation types for the (default) review
navigator

Add navigatorId to each registered annotation type

Consistently put the enabledSelector property
below the navigatorId property