### PR TITLE
Allow acknowledgeable errors in the resolve form

### DIFF
--- a/src/ui/comment/CommentCardContent.tsx
+++ b/src/ui/comment/CommentCardContent.tsx
@@ -278,6 +278,9 @@ function CommentCardContent({
 					onReplyFormSubmit={onReplyFormSubmit}
 					onReplyRefresh={onReplyRefresh}
 					onReplyRemove={onReplyRemove}
+					onReviewAnnotationErrorAcknowledge={
+						onReviewAnnotationErrorAcknowledge
+					}
 					onReviewAnnotationFormCancel={onReviewAnnotationFormCancel}
 					onReviewAnnotationFormSubmit={onReviewAnnotationFormSubmit}
 					onReviewAnnotationRefresh={onReviewAnnotationRefresh}

--- a/src/ui/proposal/ProposalCardContent.tsx
+++ b/src/ui/proposal/ProposalCardContent.tsx
@@ -303,6 +303,9 @@ const ProposalCardContent: React.FC<ReviewCardContentComponentProps> = ({
 					onReplyFormSubmit={onReplyFormSubmit}
 					onReplyRefresh={onReplyRefresh}
 					onReplyRemove={onReplyRemove}
+					onReviewAnnotationErrorAcknowledge={
+						onReviewAnnotationErrorAcknowledge
+					}
 					onReviewAnnotationFormCancel={onReviewAnnotationFormCancel}
 					onReviewAnnotationFormSubmit={onReviewAnnotationFormSubmit}
 					onReviewAnnotationRefresh={onReviewAnnotationRefresh}

--- a/src/ui/shared/CardRepliesAndResolution.tsx
+++ b/src/ui/shared/CardRepliesAndResolution.tsx
@@ -32,6 +32,7 @@ type Props = {
 	onReplyFormSubmit: ReviewCardContentComponentProps['onReplyFormSubmit'];
 	onReplyRefresh: ReviewCardContentComponentProps['onReplyRefresh'];
 	onReplyRemove: ReviewCardContentComponentProps['onReplyRemove'];
+	onReviewAnnotationErrorAcknowledge: ReviewCardContentComponentProps['onReviewAnnotationErrorAcknowledge'];
 	onReviewAnnotationFormCancel: ReviewCardContentComponentProps['onReviewAnnotationFormCancel'];
 	onReviewAnnotationFormSubmit: ReviewCardContentComponentProps['onReviewAnnotationFormSubmit'];
 	onReviewAnnotationRefresh: ReviewCardContentComponentProps['onReviewAnnotationRefresh'];
@@ -48,6 +49,7 @@ const CardRepliesAndResolution: React.FC<Props> = ({
 	onReplyFormSubmit,
 	onReplyRefresh,
 	onReplyRemove,
+	onReviewAnnotationErrorAcknowledge,
 	onReviewAnnotationFormCancel,
 	onReviewAnnotationFormSubmit,
 	onReviewAnnotationRefresh,
@@ -219,6 +221,9 @@ const CardRepliesAndResolution: React.FC<Props> = ({
 					context={context}
 					onCancel={onReviewAnnotationFormCancel}
 					onProposalMerge={onProposalMerge}
+					onReviewAnnotationErrorAcknowledge={
+						onReviewAnnotationErrorAcknowledge
+					}
 					onReviewAnnotationRefresh={onReviewAnnotationRefresh}
 					onSubmit={onReviewAnnotationFormSubmit}
 					reviewAnnotation={reviewAnnotation}

--- a/src/ui/shared/ResolveForm.tsx
+++ b/src/ui/shared/ResolveForm.tsx
@@ -63,6 +63,7 @@ function ResolveFormContent({
 	isSubmitDisabled,
 	onCancel,
 	onProposalMerge,
+	onReviewAnnotationErrorAcknowledge,
 	onReviewAnnotationRefresh,
 	onSubmit,
 	reviewAnnotation,
@@ -151,6 +152,7 @@ function ResolveFormContent({
 				{error && (
 					<ErrorToast
 						error={typeof error !== 'number' ? error : null}
+						onHideLinkClick={onReviewAnnotationErrorAcknowledge}
 						onRefreshLinkClick={onReviewAnnotationRefresh}
 						onRetryLinkClick={onSubmit}
 					/>
@@ -242,6 +244,7 @@ type Props = {
 	reviewAnnotation: ReviewCardContentComponentProps['reviewAnnotation'];
 	onCancel: ReviewCardContentComponentProps['onReviewAnnotationFormCancel'];
 	onProposalMerge: ReviewCardContentComponentProps['onProposalMerge'];
+	onReviewAnnotationErrorAcknowledge: ReviewCardContentComponentProps['onReviewAnnotationErrorAcknowledge'];
 	onReviewAnnotationRefresh: ReviewCardContentComponentProps['onReviewAnnotationRefresh'];
 	onSubmit(valueByName: FdsFormValueByName): void;
 };
@@ -251,6 +254,7 @@ const ResolveForm: React.FC<Props> = ({
 	reviewAnnotation,
 	onCancel,
 	onProposalMerge = null,
+	onReviewAnnotationErrorAcknowledge,
 	onReviewAnnotationRefresh,
 	onSubmit,
 }) => {
@@ -266,6 +270,9 @@ const ResolveForm: React.FC<Props> = ({
 					isSubmitDisabled={isSubmitDisabled}
 					onCancel={onCancel}
 					onProposalMerge={onProposalMerge}
+					onReviewAnnotationErrorAcknowledge={
+						onReviewAnnotationErrorAcknowledge
+					}
 					onReviewAnnotationRefresh={onReviewAnnotationRefresh}
 					onSubmit={onSubmit}
 					reviewAnnotation={reviewAnnotation}


### PR DESCRIPTION
This passes the acknowledge callback down to the ResolveForm's ErrorToast. Without that, any acknowledgeable error would show the error but not the link required to resolve it.