### PR TITLE
Dev 26575 Extend productContext and FeedbackContextType with DH routes

### DIFF
--- a/src/ui/comment/CommentCardContent.tsx
+++ b/src/ui/comment/CommentCardContent.tsx
@@ -80,7 +80,9 @@ function CommentCardContent({
 	const showFooter =
 		showReplyButton &&
 		(context === FeedbackContextType.EDITOR ||
-			context === FeedbackContextType.REVIEW) &&
+			context === FeedbackContextType.REVIEW ||
+			context === FeedbackContextType.EDITOR_DOCUMENT_HISTORY ||
+	 		context === FeedbackContextType.REVIEW_DOCUMENT_HISTORY) &&
 		reviewAnnotation.isSelected &&
 		reviewAnnotation.busyState !== ReviewBusyState.ADDING &&
 		reviewAnnotation.busyState !== ReviewBusyState.EDITING &&

--- a/src/ui/proposal/ProposalCardContent.tsx
+++ b/src/ui/proposal/ProposalCardContent.tsx
@@ -73,7 +73,8 @@ const ProposalCardContent: React.FC<ReviewCardContentComponentProps> = ({
 	}, [reviewAnnotation.replies]);
 
 	const showAcceptProposalButton =
-		context === FeedbackContextType.EDITOR &&
+		(context === FeedbackContextType.EDITOR ||
+			context === FeedbackContextType.EDITOR_DOCUMENT_HISTORY) &&
 		reviewAnnotation.status !== ReviewAnnotationStatus.RESOLVED &&
 		onProposalMerge &&
 		!!reviewAnnotation.proposalState;
@@ -92,7 +93,9 @@ const ProposalCardContent: React.FC<ReviewCardContentComponentProps> = ({
 	const showFooter =
 		showAnyFooterButton &&
 		(context === FeedbackContextType.EDITOR ||
-			context === FeedbackContextType.REVIEW) &&
+			context === FeedbackContextType.REVIEW ||
+			context === FeedbackContextType.EDITOR_DOCUMENT_HISTORY ||
+	 		context === FeedbackContextType.REVIEW_DOCUMENT_HISTORY) &&
 		reviewAnnotation.isSelected &&
 		reviewAnnotation.busyState !== ReviewBusyState.ADDING &&
 		reviewAnnotation.busyState !== ReviewBusyState.EDITING &&

--- a/src/ui/proposal/ProposalCardContent.tsx
+++ b/src/ui/proposal/ProposalCardContent.tsx
@@ -73,8 +73,7 @@ const ProposalCardContent: React.FC<ReviewCardContentComponentProps> = ({
 	}, [reviewAnnotation.replies]);
 
 	const showAcceptProposalButton =
-		(context === FeedbackContextType.EDITOR ||
-			context === FeedbackContextType.EDITOR_DOCUMENT_HISTORY) &&
+		context === FeedbackContextType.EDITOR &&
 		reviewAnnotation.status !== ReviewAnnotationStatus.RESOLVED &&
 		onProposalMerge &&
 		!!reviewAnnotation.proposalState;

--- a/src/ui/shared/CardHeader.tsx
+++ b/src/ui/shared/CardHeader.tsx
@@ -320,7 +320,9 @@ const CardHeader: React.FC<Props> = ({
 
 			<Flex flex="0 0 auto" spaceSize="m">
 				{(context === FeedbackContextType.EDITOR_SHARING ||
-					context === FeedbackContextType.REVIEW_SHARING) &&
+					context === FeedbackContextType.REVIEW_SHARING ||
+					context === FeedbackContextType.EDITOR_DOCUMENT_HISTORY_SHARING ||
+					context === FeedbackContextType.REVIEW_DOCUMENT_HISTORY_SHARING) &&
 					(!reviewAnnotation.error ||
 						(typeof reviewAnnotation.error !== 'number' &&
 							reviewAnnotation.error.recovery ===
@@ -338,7 +340,9 @@ const CardHeader: React.FC<Props> = ({
 					)}
 
 				{context !== FeedbackContextType.EDITOR_SHARING &&
-					context !== FeedbackContextType.REVIEW_SHARING && (
+					context !== FeedbackContextType.REVIEW_SHARING && 
+					context !== FeedbackContextType.EDITOR_DOCUMENT_HISTORY_SHARING &&
+					context !== FeedbackContextType.REVIEW_DOCUMENT_HISTORY_SHARING && (
 						<Flex alignItems="center" spaceSize="m">
 							{showShareButton && (
 								<Button

--- a/src/ui/shared/CardHeader.tsx
+++ b/src/ui/shared/CardHeader.tsx
@@ -247,7 +247,9 @@ const CardHeader: React.FC<Props> = ({
 		reviewAnnotation.busyState !== ReviewBusyState.EDITING &&
 		reviewAnnotation.status === ReviewAnnotationStatus.PRIVATE &&
 		(context === FeedbackContextType.EDITOR ||
-			context === FeedbackContextType.REVIEW);
+			context === FeedbackContextType.REVIEW ||
+			context === FeedbackContextType.EDITOR_DOCUMENT_HISTORY ||
+	 		context === FeedbackContextType.REVIEW_DOCUMENT_HISTORY);
 
 	const shareButtonLabel =
 		reviewAnnotation.isSelected &&

--- a/src/ui/shared/ResolveForm.tsx
+++ b/src/ui/shared/ResolveForm.tsx
@@ -97,10 +97,11 @@ function ResolveFormContent({
 		proposalState !== ReviewProposalState.MERGED &&
 		valueByName.resolution === 'accepted';
 
-	const isInReview =
-		context === FeedbackContextType.REVIEW ||
-		context === FeedbackContextType.REVIEW_DOCUMENT_HISTORY ||
-		context === FeedbackContextType.REVIEW_SHARING;
+	const showAcceptProposalButton =
+		context === FeedbackContextType.EDITOR &&
+		reviewAnnotation.status !== ReviewAnnotationStatus.RESOLVED &&
+		onProposalMerge &&
+		!!reviewAnnotation.proposalState;
 
 	const handleResolveButtonClick = React.useCallback(
 		(_event: MouseEvent) => {
@@ -215,12 +216,7 @@ function ResolveFormContent({
 						onClick={onCancel}
 					/>
 
-					{!isInReview &&
-						reviewAnnotation.type === 'proposal' &&
-						reviewAnnotation.status !==
-							ReviewAnnotationStatus.RESOLVED &&
-						onProposalMerge &&
-						proposalState && (
+					{showAcceptProposalButton && (
 							<ReviewAnnotationAcceptProposalButton
 								onProposalMerge={onProposalMerge}
 								proposalState={proposalState}

--- a/src/ui/shared/ResolveForm.tsx
+++ b/src/ui/shared/ResolveForm.tsx
@@ -99,6 +99,7 @@ function ResolveFormContent({
 
 	const isInReview =
 		context === FeedbackContextType.REVIEW ||
+		context === FeedbackContextType.REVIEW_DOCUMENT_HISTORY ||
 		context === FeedbackContextType.REVIEW_SHARING;
 
 	const handleResolveButtonClick = React.useCallback(


### PR DESCRIPTION
Uses the new enum values added in FeedbackContextType in the Document History routes.

Significant changes:

- Shows footer in all views to add replies
- Shows Share button in all views
- Only shows ReviewAnnotationAcceptProposalButton on the editor view, as the content cannot be changed on other views

