### PR TITLE
DEV-26717 Make buttons behave consistently between forms based on conflict state

### DIFF
--- a/src/ui/shared/AddOrEditFormFooter.tsx
+++ b/src/ui/shared/AddOrEditFormFooter.tsx
@@ -73,11 +73,7 @@ const AddOrEditFormFooter: React.FC<Props> = ({
 
 			{areFormButtonsVisible && (
 				<Flex justifyContent="flex-end" spaceSize="m">
-					<Button
-						isDisabled={isDisabled}
-						label={t('Cancel')}
-						onClick={onCancel}
-					/>
+					<Button label={t('Cancel')} onClick={onCancel} />
 
 					<Button
 						icon={isLoading ? 'spinner' : null}

--- a/src/ui/shared/ReplyForm.tsx
+++ b/src/ui/shared/ReplyForm.tsx
@@ -104,6 +104,11 @@ const ReplyFormContent: React.FC<ReplyFormContentProps> = ({
 			? reply.error
 			: null;
 
+	const areFormButtonsVisible = !(
+		error &&
+		typeof error !== 'number' &&
+		error.recovery === ReviewRecoveryOption.ACKNOWLEDGEABLE
+	);
 	const isDisabled =
 		reply.isLoading ||
 		(error && error.recovery !== ReviewRecoveryOption.RETRYABLE);
@@ -160,21 +165,23 @@ const ReplyFormContent: React.FC<ReplyFormContentProps> = ({
 				)}
 			</Flex>
 
-			<Flex justifyContent="flex-end" spaceSize="m">
-				<Button label={t('Cancel')} onClick={onCancelButtonClick} />
+			{areFormButtonsVisible && (
+				<Flex justifyContent="flex-end" spaceSize="m">
+					<Button label={t('Cancel')} onClick={onCancelButtonClick} />
 
-				<Button
-					icon={isLoading ? 'spinner' : null}
-					isDisabled={isDisabled || isLoading || isSubmitDisabled}
-					label={determineSaveButtonLabel(
-						error,
-						isEditing,
-						isLoading
-					)}
-					onClick={handleReplyButtonClick}
-					type="primary"
-				/>
-			</Flex>
+					<Button
+						icon={isLoading ? 'spinner' : null}
+						isDisabled={isDisabled || isLoading || isSubmitDisabled}
+						label={determineSaveButtonLabel(
+							error,
+							isEditing,
+							isLoading
+						)}
+						onClick={handleReplyButtonClick}
+						type="primary"
+					/>
+				</Flex>
+			)}
 		</Block>
 	);
 };

--- a/src/ui/shared/ResolveForm.tsx
+++ b/src/ui/shared/ResolveForm.tsx
@@ -73,6 +73,11 @@ function ResolveFormContent({
 	valueByName: FdsFormValueByName;
 }) {
 	const error = reviewAnnotation.error ? reviewAnnotation.error : null;
+	const areFormButtonsVisible = !(
+		error &&
+		typeof error !== 'number' &&
+		error.recovery === ReviewRecoveryOption.ACKNOWLEDGEABLE
+	);
 	const isDisabled =
 		reviewAnnotation.isLoading ||
 		(typeof error !== 'number' &&
@@ -203,34 +208,34 @@ function ResolveFormContent({
 					/>
 				)}
 
-				<Flex
-					alignItems="center"
-					ariaRole="status"
-					applyCss={footerButtonContainerStyles}
-					justifyContent="flex-end"
-					spaceSize="m"
-				>
-					<Button
-						isDisabled={isDisabled}
-						label={t('Cancel')}
-						onClick={onCancel}
-					/>
+				{areFormButtonsVisible && (
+					<Flex
+						alignItems="center"
+						ariaRole="status"
+						applyCss={footerButtonContainerStyles}
+						justifyContent="flex-end"
+						spaceSize="m"
+					>
+						<Button label={t('Cancel')} onClick={onCancel} />
 
-					{showAcceptProposalButton && (
+						{showAcceptProposalButton && (
 							<ReviewAnnotationAcceptProposalButton
 								onProposalMerge={onProposalMerge}
 								proposalState={proposalState}
 							/>
 						)}
 
-					<Button
-						icon={isLoading ? 'spinner' : null}
-						isDisabled={isDisabled || isLoading || isSubmitDisabled}
-						label={determineSaveButtonLabel(error, isLoading)}
-						onClick={handleResolveButtonClick}
-						type="primary"
-					/>
-				</Flex>
+						<Button
+							icon={isLoading ? 'spinner' : null}
+							isDisabled={
+								isDisabled || isLoading || isSubmitDisabled
+							}
+							label={determineSaveButtonLabel(error, isLoading)}
+							onClick={handleResolveButtonClick}
+							type="primary"
+						/>
+					</Flex>
+				)}
 			</Block>
 		</Block>
 	);


### PR DESCRIPTION
This fixes a few inconsistencies in the way each form's buttons would behave in conflict states, in particular in acknowledgeable ones vs. others. Acknowledgeable conflicts now consistently show no buttons at all. In all other cases, the Cancel button is now always enabled as it will have the same effect as clicking Refresh.