### PR TITLE
DEV-27077 Disable cancel button while a request is in flight

### DIFF
--- a/src/ui/shared/AddOrEditFormFooter.tsx
+++ b/src/ui/shared/AddOrEditFormFooter.tsx
@@ -73,7 +73,11 @@ const AddOrEditFormFooter: React.FC<Props> = ({
 
 			{areFormButtonsVisible && (
 				<Flex justifyContent="flex-end" spaceSize="m">
-					<Button label={t('Cancel')} onClick={onCancel} />
+					<Button
+						isDisabled={isLoading}
+						label={t('Cancel')}
+						onClick={onCancel}
+					/>
 
 					<Button
 						icon={isLoading ? 'spinner' : null}

--- a/src/ui/shared/ReplyForm.tsx
+++ b/src/ui/shared/ReplyForm.tsx
@@ -112,7 +112,7 @@ const ReplyFormContent: React.FC<ReplyFormContentProps> = ({
 	const isDisabled =
 		reply.isLoading ||
 		(error && error.recovery !== ReviewRecoveryOption.RETRYABLE);
-	const isLoading = reply.isLoading && (isAdding || isEditing);
+	const isLoading = !!reply.isLoading && (isAdding || isEditing);
 
 	const handleReplyDirChange = React.useCallback(
 		(dir) => {
@@ -167,7 +167,11 @@ const ReplyFormContent: React.FC<ReplyFormContentProps> = ({
 
 			{areFormButtonsVisible && (
 				<Flex justifyContent="flex-end" spaceSize="m">
-					<Button label={t('Cancel')} onClick={onCancelButtonClick} />
+					<Button
+						isDisabled={isLoading}
+						label={t('Cancel')}
+						onClick={onCancelButtonClick}
+					/>
 
 					<Button
 						icon={isLoading ? 'spinner' : null}

--- a/src/ui/shared/ResolveForm.tsx
+++ b/src/ui/shared/ResolveForm.tsx
@@ -216,7 +216,11 @@ function ResolveFormContent({
 						justifyContent="flex-end"
 						spaceSize="m"
 					>
-						<Button label={t('Cancel')} onClick={onCancel} />
+						<Button
+							isDisabled={isLoading}
+							label={t('Cancel')}
+							onClick={onCancel}
+						/>
 
 						{showAcceptProposalButton && (
 							<ReviewAnnotationAcceptProposalButton


### PR DESCRIPTION
Apply this behavior to all forms that have a cancel button: 
add & edit annotation
add & edit replies
resolve annotation

This prevents an error while trying to cancel mid-request (isLoading === true); 
the manager was never intended to support that.