### PR TITLE
DEV-27129 Add reply input field instead of button in history route

### DIFF
--- a/src/ui/proposal/ProposalCardContent.tsx
+++ b/src/ui/proposal/ProposalCardContent.tsx
@@ -94,7 +94,7 @@ const ProposalCardContent: React.FC<ReviewCardContentComponentProps> = ({
 		(context === FeedbackContextType.EDITOR ||
 			context === FeedbackContextType.REVIEW ||
 			context === FeedbackContextType.EDITOR_DOCUMENT_HISTORY ||
-	 		context === FeedbackContextType.REVIEW_DOCUMENT_HISTORY) &&
+			context === FeedbackContextType.REVIEW_DOCUMENT_HISTORY) &&
 		reviewAnnotation.isSelected &&
 		reviewAnnotation.busyState !== ReviewBusyState.ADDING &&
 		reviewAnnotation.busyState !== ReviewBusyState.EDITING &&
@@ -346,6 +346,7 @@ const ProposalCardContent: React.FC<ReviewCardContentComponentProps> = ({
 						>
 							{showReplyButton && (
 								<ProposalReplyComponent
+									context={context}
 									onReplyAdd={onReplyAdd}
 									reviewAnnotation={reviewAnnotation}
 								/>

--- a/src/ui/proposal/ProposalReplyComponent.tsx
+++ b/src/ui/proposal/ProposalReplyComponent.tsx
@@ -16,13 +16,18 @@ const ProposalReplyComponent: React.FC<Props> = ({
 	onReplyAdd,
 	reviewAnnotation,
 }) => {
-	// Check if we are on the "/review" route.
+	// Check if we are on the "/review" or "/*/history" route.
 	const { path } = useRouteMatch();
-	const isOnReviewRoute = path === '/review';
+
+	const isOnReviewOrHistoryRoute = [
+		'/review',
+		'/review/history',
+		'/editor/history',
+	].includes(path);
 
 	// If we are on the review route, we need to show the text input
 	// to add the reply.
-	if (isOnReviewRoute) {
+	if (isOnReviewOrHistoryRoute) {
 		return (
 			<ProposalCardFooter
 				onReplyAdd={onReplyAdd}

--- a/src/ui/proposal/ProposalReplyComponent.tsx
+++ b/src/ui/proposal/ProposalReplyComponent.tsx
@@ -1,32 +1,31 @@
 import * as React from 'react';
-import { useRouteMatch } from 'react-router-dom';
 
 import { Button } from 'fontoxml-design-system/src/components';
+import FeedbackContextType from 'fontoxml-feedback/src/FeedbackContextType';
 import type { ReviewCardContentComponentProps } from 'fontoxml-feedback/src/types';
 import t from 'fontoxml-localization/src/t';
 
 import ProposalCardFooter from './ProposalCardFooter';
 
 type Props = {
+	context: ReviewCardContentComponentProps['context'];
 	onReplyAdd: ReviewCardContentComponentProps['onReplyAdd'];
 	reviewAnnotation: ReviewCardContentComponentProps['reviewAnnotation'];
 };
 
 const ProposalReplyComponent: React.FC<Props> = ({
+	context,
 	onReplyAdd,
 	reviewAnnotation,
 }) => {
 	// Check if we are on the "/review" or "/*/history" route.
-	const { path } = useRouteMatch();
+	const isOnReviewOrHistoryRoute =
+		context === FeedbackContextType.REVIEW ||
+		context === FeedbackContextType.REVIEW_DOCUMENT_HISTORY ||
+		context === FeedbackContextType.EDITOR_DOCUMENT_HISTORY;
 
-	const isOnReviewOrHistoryRoute = [
-		'/review',
-		'/review/history',
-		'/editor/history',
-	].includes(path);
-
-	// If we are on the review route, we need to show the text input
-	// to add the reply.
+	// If we are on the review or history route, we need to show the
+	// text input to add the reply.
 	if (isOnReviewOrHistoryRoute) {
 		return (
 			<ProposalCardFooter


### PR DESCRIPTION
In the DH route, there’s no apply changes functionality on proposals, so we can do the same we’re doing in the Review route, which is showing an input field directly, just like for regular comments.